### PR TITLE
v2.2: Add GitHub Sync Hub dispatch workflow

### DIFF
--- a/.github/workflows/dispatch-to-hub.yml
+++ b/.github/workflows/dispatch-to-hub.yml
@@ -1,0 +1,31 @@
+name: Dispatch to Sync Hub
+
+on:
+  issues:
+    types: [opened, edited, deleted, closed, reopened, labeled, unlabeled, assigned, unassigned, milestoned, demilestoned]
+  pull_request:
+    types: [closed]
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch Sync Event
+        env:
+          SYNC_TOKEN: ${{ secrets.GH_SYNC_TOKEN }}
+          EVENT_CONTEXT: ${{ toJson(github.event) }}
+          REPO_NAME: ${{ github.repository }}
+        run: |
+          # Use jq to safely construct the JSON payload to avoid shell injection and quoting issues
+          PAYLOAD=$(jq -n \
+            --arg repo "$REPO_NAME" \
+            --argjson event "$EVENT_CONTEXT" \
+            '{event_type: "github_sync", client_payload: {repo: $repo, event: $event}}')
+
+          curl -L \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer $SYNC_TOKEN" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/l-souljourney/souljourney-code/dispatches \
+            -d "$PAYLOAD"


### PR DESCRIPTION
## Summary
- Created `.github/workflows/dispatch-to-hub.yml` to notify the `l-souljourney/souljourney-code` repository (Hub) when issues are modified or PRs are closed.
- Implementation uses `jq` to safely handle the GitHub event context and prevent shell injection or quoting issues.

## Verification
- Verified file existence and content.
- Validated triggers: `issues` (all types) and `pull_request` (closed).
- Checked secure payload construction.

Fixes #3