### PR TITLE
<v2.0.0> fix COS deploy endpoint to regional domain

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -64,13 +64,16 @@ jobs:
           COS_SECRET_KEY: ${{ secrets.TENCENT_CLOUD_SECRET_KEY }}
           COS_BUCKET: ${{ secrets.COS_BUCKET }}
           COS_REGION: ${{ secrets.COS_REGION }}
-          COS_ACCELERATE_ENDPOINT: cos.accelerate.myqcloud.com
         run: |
           if [ ! -d "dist" ]; then
             echo "❌ dist directory not found"
             exit 1
           fi
           echo "✅ dist exists: $(du -sh dist/ | cut -f1)"
+
+          COS_ENDPOINT="cos.${COS_REGION}.myqcloud.com"
+          echo "📦 COS endpoint: ${COS_ENDPOINT}"
+          START_TS=$(date +%s)
 
           docker run --rm \
             -v "$PWD/dist:/workspace/dist" \
@@ -79,8 +82,11 @@ jobs:
             -lc "
               coscli config set --secret_id \"${COS_SECRET_ID}\" --secret_key \"${COS_SECRET_KEY}\" &&
               coscli config add --init-skip=true -b \"${COS_BUCKET}\" -r \"${COS_REGION}\" &&
-              coscli sync /workspace/dist/ \"cos://${COS_BUCKET}/\" --delete --force --disable-crc64 --recursive --endpoint \"${COS_ACCELERATE_ENDPOINT}\"
+              coscli sync /workspace/dist/ \"cos://${COS_BUCKET}/\" --delete --force --disable-crc64 --recursive --endpoint \"${COS_ENDPOINT}\"
             "
+
+          END_TS=$(date +%s)
+          echo "⏱️ COS sync duration: $((END_TS - START_TS))s"
 
       - name: Purge CDN cache (optional)
         env:


### PR DESCRIPTION
## Summary
- switch COS upload endpoint from global accelerate domain to regional default endpoint `cos.${COS_REGION}.myqcloud.com`
- add deploy-time logs for endpoint and sync duration to evaluate upload performance on incremental updates

## Issue
Refs #6

## Verification
- previous main deploy failed at `cos.accelerate.myqcloud.com` with HTTP 400
- this PR tests upload via default regional endpoint and records sync duration in Action logs