### PR TITLE
<v2.0.0> fix deploy verification with scheme-safe domain parsing

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -153,6 +153,9 @@ jobs:
           verify_domain() {
             local domain="$1"
             local label="$2"
+            domain="${domain#http://}"
+            domain="${domain#https://}"
+            domain="${domain%/}"
             local url="https://${domain}/build-meta.json"
 
             if [ -z "${domain}" ]; then


### PR DESCRIPTION
## Summary
- normalize verification domains by stripping `http://`, `https://`, and trailing `/` before curl checks
- fixes false failures when `CDN_DOMAIN` is stored with URL scheme

## Issue
Refs #6

## Verification
- workflow logic update only
- addresses run failure in main deploy verify-production job caused by malformed URL `https://https://...`