### PR TITLE
<v2.0.0> add manual trigger for deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,6 +1,7 @@
 name: Deploy to COS + CDN
 
 on:
+  workflow_dispatch:
   push:
     branches: [main]
 


### PR DESCRIPTION
## Summary
- add `workflow_dispatch` so deploy can be manually triggered for verification

## Issue
Refs #6

## Verification
- workflow config change only