### PR TITLE
<v2.0.0> run deploy jobs on workflow_dispatch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -54,7 +54,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main'
     steps:
       - name: Download build artifacts
         uses: actions/download-artifact@v4
@@ -143,7 +143,7 @@ jobs:
     needs: deploy-cos
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main'
     env:
       PRIMARY_DOMAIN: ${{ vars.PRIMARY_DOMAIN }}
       PAGES_DOMAIN: ${{ vars.PAGES_DOMAIN }}


### PR DESCRIPTION
## Summary
- allow deploy-cos and verify-production jobs to run on manual workflow_dispatch

## Issue
Refs #6

## Verification
- workflow condition update only