### PR TITLE
<v2.1.1> Astro SEO/内容完整性守卫

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -14,10 +14,13 @@ import rehypeSlug from "rehype-slug";
 import rehypeKatex from "rehype-katex";
 import remarkDirective from "remark-directive";
 import { remarkNote, addClassNames } from './src/plugins/markdown.custom'
+import { validateMarkdownIntegrityInDir } from './src/utils/contentIntegrityFs'
 // Markdown 配置================
 import SITE_INFO from './src/config';
 
 import tailwind from "@astrojs/tailwind";
+
+validateMarkdownIntegrityInDir(path.resolve(__dirname, "./src/content/blog"));
 
 // https://astro.build/config
 export default defineConfig({

--- a/openspec/changes/v2-1-1-astro-seo-content-guard/.openspec.yaml
+++ b/openspec/changes/v2-1-1-astro-seo-content-guard/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-24

--- a/openspec/changes/v2-1-1-astro-seo-content-guard/design.md
+++ b/openspec/changes/v2-1-1-astro-seo-content-guard/design.md
@@ -1,0 +1,52 @@
+## Overview
+
+v2.1.1 聚焦三个点：
+
+1. **语言 alternate 安全化**：文章页只有在“对侧语言同 slug 稿件存在”时才输出 alternate 与切换目标。
+2. **正文污染前置拦截**：构建期检测正文起始的重复 frontmatter 模式，检测到即失败。
+3. **摘要来源修正**：摘要优先使用 frontmatter `description`，避免正文污染影响 meta/OG/Twitter。
+
+## Detailed Design
+
+### 1) Article alternate existence check
+
+- 新增工具函数（Astro 侧）：
+  - 识别当前是否是文章路由（`/article/{slug}` 或 `/en/article/{slug}`）
+  - 基于 `astro:content` 查询是否存在同 slug 的对侧语言文章
+- `Head.astro`：
+  - 文章页有对侧稿件：输出 `zh/en/x-default`
+  - 文章页无对侧稿件：仅输出当前语言与 `x-default`（指向当前语言 URL）
+- `Header.astro`：
+  - 文章页有对侧稿件：语言切换按钮跳转对侧文章
+  - 文章页无对侧稿件：语言切换按钮回退对应语言首页（避免 404）
+
+### 2) Content contamination guard
+
+- 在 markdown 处理链增加校验：
+  - 对正文起始片段（trim 后前 N 字符）检查是否包含 `--- ... ---` 块
+  - 命中则抛错并终止构建，错误信息包含文件标识
+- 守卫目标：拦截“frontmatter + frontmatter + body”这类重复注入。
+- 为降低误伤，仅检测正文起始位置，不扫描全文任意位置。
+
+### 3) Description fallback strategy
+
+- `getDescription(post)` 改为：
+  1. frontmatter `description` 非空则直接返回；
+  2. 否则先执行正文污染校验；
+  3. 校验通过后再基于正文提取摘要。
+
+## Risks and Mitigations
+
+- **风险：误判 markdown 教学文中的 YAML 示例**
+  - 缓解：只检测正文“起始片段”的 frontmatter 块，不匹配中段示例。
+- **风险：`getCollection` 在头部组件增加构建耗时**
+  - 缓解：仅文章路由触发存在性查询；非文章页不做查询。
+
+## Verification Plan
+
+- 正向：
+  - `pnpm build` 通过；
+  - 中文单语文章不再输出无效英文 `hreflang`；
+  - 语言切换按钮不再指向不存在的 `/en/article/{slug}`。
+- 负向：
+  - 构造正文起始重复 frontmatter 样例，构建应失败并给出可读错误。

--- a/openspec/changes/v2-1-1-astro-seo-content-guard/proposal.md
+++ b/openspec/changes/v2-1-1-astro-seo-content-guard/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+v2.1 已完成发布契约与 slug 路由统一，但线上新文章暴露两个缺口：
+
+- 正文污染（重复 frontmatter 块）会进入页面与 SEO 描述，降低内容质量与搜索质量。
+- `hreflang` 与语言切换目前按路径机械拼接，文章无对应英文稿时会产生 404 目标。
+
+v2.1.1 目标是增加 Astro 展示层与构建期守卫，避免错误内容继续放大。
+
+## What Changes
+
+- 为文章页面增加“跨语言稿件存在性判断”，仅在存在对应稿件时输出 `hreflang=en/zh` 与文章页语言切换链接。
+- 引入正文污染检测守卫：若正文起始出现疑似第二段 frontmatter（`--- ... ---`）则构建失败。
+- `description` 生成策略调整为：优先 frontmatter `description`，否则回退正文摘要（先通过污染检测）。
+- 清理已落库污染样例 `obs-1e2bf5c7` 的重复 frontmatter 段，恢复单 frontmatter 文档结构。
+
+## Non-goals
+
+- 不修改 Obsidian 插件与 wxengine 逻辑（由各自仓库负责）。
+- 不改动站点视觉、路由结构、分类与 schema 契约字段。
+- 不做历史全量内容治理脚本，仅处理当前已确认污染样例。
+
+## Impact
+
+- 代码范围：`src/components/Head/Head.astro`、`src/components/Header/Header.astro`、`src/utils/index.ts`、`src/plugins/*`、`src/content/blog/zh/obs-1e2bf5c7.md`
+- 行为影响：SEO alternate 与语言切换更严格；正文污染从“上线后可见问题”前移为“构建失败问题”。
+- 发布收益：减少脏内容上线概率，避免无效 hreflang 导致的 SEO 噪音。

--- a/openspec/changes/v2-1-1-astro-seo-content-guard/specs/astro-content-integrity-guard/spec.md
+++ b/openspec/changes/v2-1-1-astro-seo-content-guard/specs/astro-content-integrity-guard/spec.md
@@ -1,0 +1,17 @@
+## ADDED Requirements
+
+### Requirement: Build SHALL fail on duplicate frontmatter at body start
+
+Astro markdown processing MUST reject content whose body begins with a second frontmatter block (`--- ... ---`) after the primary frontmatter has already been parsed.
+
+#### Scenario: duplicated frontmatter is detected
+- **WHEN** markdown body starts with `---` followed by key-value YAML-like lines and closing `---`
+- **THEN** build fails with a readable error containing file identity
+
+### Requirement: Summary extraction SHALL run after integrity check
+
+Any fallback summary extraction from markdown body MUST run only after content-integrity checks pass.
+
+#### Scenario: integrity violation before summary extraction
+- **WHEN** duplicate frontmatter exists in body start
+- **THEN** fallback summary extraction is aborted and build fails

--- a/openspec/changes/v2-1-1-astro-seo-content-guard/specs/astro-slug-route-stability/spec.md
+++ b/openspec/changes/v2-1-1-astro-seo-content-guard/specs/astro-slug-route-stability/spec.md
@@ -1,0 +1,21 @@
+## ADDED Requirements
+
+### Requirement: Article hreflang SHALL only reference existing counterpart content
+
+For article detail routes, hreflang alternate links MUST be emitted only when the corresponding opposite-language article exists for the same slug.
+
+#### Scenario: zh article without en counterpart
+- **WHEN** rendering `/article/{slug}` and no `/en/article/{slug}` content exists
+- **THEN** page head MUST NOT emit `hreflang="en"` pointing to that missing route
+
+#### Scenario: bilingual article pair exists
+- **WHEN** both zh and en entries exist for the same slug
+- **THEN** page head emits valid `hreflang="zh"` and `hreflang="en"` alternates
+
+### Requirement: Article language switch SHALL avoid dead-end route
+
+Language switch behavior on article pages MUST avoid linking to non-existent counterpart article routes.
+
+#### Scenario: missing counterpart article
+- **WHEN** current article has no opposite-language entry
+- **THEN** language switch target falls back to language homepage instead of dead article route

--- a/openspec/changes/v2-1-1-astro-seo-content-guard/specs/astro-taxonomy-and-meta-normalization/spec.md
+++ b/openspec/changes/v2-1-1-astro-seo-content-guard/specs/astro-taxonomy-and-meta-normalization/spec.md
@@ -1,0 +1,13 @@
+## ADDED Requirements
+
+### Requirement: Description metadata SHALL prefer explicit frontmatter description
+
+Article description resolution MUST prefer frontmatter `description` when present and non-empty.
+
+#### Scenario: frontmatter description exists
+- **WHEN** rendering article meta tags and list excerpts
+- **THEN** description text is sourced from frontmatter `description`
+
+#### Scenario: frontmatter description missing
+- **WHEN** `description` is absent in frontmatter
+- **THEN** system falls back to generated excerpt from sanitized body content

--- a/openspec/changes/v2-1-1-astro-seo-content-guard/tasks.md
+++ b/openspec/changes/v2-1-1-astro-seo-content-guard/tasks.md
@@ -1,0 +1,16 @@
+## 1. Alternate 与语言切换守卫 [H]
+
+- [x] 1.1 [H] 在 `src/components/Head/Head.astro` 增加文章对侧语言存在性判断；AC: 无对侧稿件时不输出无效 `hreflang`
+- [x] 1.2 [H] 在 `src/components/Header/Header.astro` 调整文章页语言切换目标；AC: 不再跳转不存在的 `/en/article/{slug}` 或 `/article/{slug}`
+
+## 2. 正文污染构建守卫 [H]
+
+- [x] 2.1 [H] 在 markdown 处理链新增正文起始重复 frontmatter 检测；AC: 命中时构建失败并带文件标识
+- [x] 2.2 [H] 调整 `getDescription`：优先 frontmatter `description`，回退正文前执行污染检测；AC: meta 描述不再来自污染 YAML 文本
+- [x] 2.3 [M] 清理 `src/content/blog/zh/obs-1e2bf5c7.md` 的重复 frontmatter 块；AC: 文件仅保留一段 frontmatter
+
+## 3. 验证与交付 [H]
+
+- [x] 3.1 [H] 执行 `pnpm build`；AC: 构建通过
+- [x] 3.2 [H] 负向验证：临时注入重复 frontmatter 样例触发失败；AC: 构建失败且错误可读
+- [ ] 3.3 [H] 线上抽查 `obs-1e2bf5c7`：`hreflang=en` 不再指向 404；AC: 页面 SEO link 符合预期

--- a/src/components/Head/Head.astro
+++ b/src/components/Head/Head.astro
@@ -1,5 +1,6 @@
 ---
 import SITE_CONFIG from "@/config";
+import { getAlternateArticlePath, parseArticleRoute } from "@/utils/articleI18n";
 // i18n
 import { getLangFromUrl, useTranslations } from '@/i18n/utils';
 const lang = getLangFromUrl(Astro.url);
@@ -9,10 +10,20 @@ const t = useTranslations(lang);
 const canonicalData = new URL(Astro.url.pathname, Astro.site);
 const canonicalURL = canonicalData.href.replace(/\/+$/, "");
 
-// 生成语言切换链接（hreflang）
-const altLangURL = lang === 'zh' 
-  ? new URL(`/en${Astro.url.pathname}`, Astro.site).href.replace(/\/+$/, "")
-  : new URL(Astro.url.pathname.replace(/^\/en/, ''), Astro.site).href.replace(/\/+$/, "");
+const articleRoute = parseArticleRoute(Astro.url.pathname);
+const articleAltPath = articleRoute ? await getAlternateArticlePath(Astro.url) : null;
+
+const defaultAltLangURL = lang === 'zh'
+	? new URL(`/en${Astro.url.pathname}`, Astro.site).href.replace(/\/+$/, "")
+	: new URL(Astro.url.pathname.replace(/^\/en/, ''), Astro.site).href.replace(/\/+$/, "");
+const altLangURL = articleAltPath
+	? new URL(articleAltPath, Astro.site).href.replace(/\/+$/, "")
+	: defaultAltLangURL;
+
+const hasArticleAltLanguage = Boolean(articleAltPath);
+const renderZhAlt = !articleRoute || lang === 'zh' || hasArticleAltLanguage;
+const renderEnAlt = !articleRoute || lang === 'en' || hasArticleAltLanguage;
+const xDefaultHref = lang === 'zh' ? canonicalURL : (renderZhAlt ? altLangURL : canonicalURL);
 
 // 页面内容的元数据
 const { Title, Keywords, Description, PageCover } = Astro.props;
@@ -95,9 +106,9 @@ const ArticleData = { "@context": "https://schema.org", "@type": "BlogPosting", 
 	<!-- LINK 标签 -->
 	<link rel="canonical" href={canonicalURL} />
 	<!-- hreflang for SEO -->
-	<link rel="alternate" hreflang="zh" href={lang === 'zh' ? canonicalURL : altLangURL} />
-	<link rel="alternate" hreflang="en" href={lang === 'en' ? canonicalURL : altLangURL} />
-	<link rel="alternate" hreflang="x-default" href={lang === 'zh' ? canonicalURL : altLangURL} />
+	{renderZhAlt && <link rel="alternate" hreflang="zh" href={lang === 'zh' ? canonicalURL : altLangURL} />}
+	{renderEnAlt && <link rel="alternate" hreflang="en" href={lang === 'en' ? canonicalURL : altLangURL} />}
+	<link rel="alternate" hreflang="x-default" href={xDefaultHref} />
 	<link rel="icon" type="image/x-icon" href="/favicon.ico" />
 	<slot />
 </head>

--- a/src/components/Header/Header.astro
+++ b/src/components/Header/Header.astro
@@ -10,6 +10,7 @@ import Svg from "@/components/Svg/Svg.astro";
 import Search from "@/components/Search/Search.astro";
 // 主题切换组件
 import ThemeIcon from "@/components/ThemeIcon/ThemeIcon.astro";
+import { getAlternateArticlePath, parseArticleRoute } from "@/utils/articleI18n";
 
 // i18n
 import { getLangFromUrl, useTranslations, getRouteFromUrl } from '@/i18n/utils';
@@ -17,10 +18,15 @@ import { getLangFromUrl, useTranslations, getRouteFromUrl } from '@/i18n/utils';
 const lang = getLangFromUrl(Astro.url);
 const t = useTranslations(lang);
 const currentRoute = getRouteFromUrl(Astro.url);
+const articleRoute = parseArticleRoute(Astro.url.pathname);
+const articleAltPath = articleRoute ? await getAlternateArticlePath(Astro.url) : null;
 
 // 简单的语言切换逻辑
 const nextLangLabel = lang === 'zh' ? 'EN' : '中';
-const nextRoute = lang === 'zh' ? `/en${currentRoute}` : currentRoute?.replace(/^\/en/, '') || '/';
+const defaultSwitchRoute = lang === 'zh' ? `/en${currentRoute}` : currentRoute?.replace(/^\/en/, '') || '/';
+const nextRoute = articleRoute
+	? (articleAltPath || (lang === 'zh' ? '/en' : '/'))
+	: defaultSwitchRoute;
 
 // 移除硬编码映射表
 // const navTextMap = ...

--- a/src/content/blog/zh/obs-1e2bf5c7.md
+++ b/src/content/blog/zh/obs-1e2bf5c7.md
@@ -23,30 +23,6 @@ article_type: news
 render_profile: default
 ---
 
----
-title: 市场的本质不是价格波动，而是认知的博弈。财富的本质不是运气，而是对供需与预期的节奏把握。
-date: 2025-10-16 12:03:44
-categories: philosophy
-tags:
-  - AI
-  - 交易
-  - 止损
-id: ""
-description: 个逻辑写出一版具有思考性、
-cover: https://cloudcos.l-souljourney.cn/blog/images/2026/mn4gfwqh_5c587558.png
-recommend: false
-top: false
-hide: false
-created: ""
-updated: 2026-03-24 18:11:31
-slug: obs-1e2bf5c7
-lang: zh
-source_id: obs_1e2bf5c7
-author: 执笔丨忠程
-word_count: 1536
-reading_time: 6
----
-
 非常好 👍
 
 你把“市场交易预期、买卖决定财富、供需决定价格”上升到**“自我认知”**的层面，这是一个非常有张力、也容易引发读者共鸣的切入点。它把经济规律转化成**人生与思维规律的隐喻**，既理性又具哲学感，非常适合你公众号/博客的内容调性。

--- a/src/plugins/markdown.custom.ts
+++ b/src/plugins/markdown.custom.ts
@@ -2,10 +2,13 @@
 import { visit } from 'unist-util-visit';
 import getReadingTime from 'reading-time';
 import { toString } from 'mdast-util-to-string';
+import { assertNoEmbeddedFrontmatterAtBodyStart } from '../utils/contentIntegrity';
 
 // 处理标签
 const remarkNote = () => {
   return (tree: any, file: any) => {
+    const fileRef = file.path || file.history?.[0] || "unknown-markdown-file";
+    assertNoEmbeddedFrontmatterAtBodyStart(String(file.value || ""), fileRef);
     // 文章字数统计
     const textOnPage = toString(tree);
     const readingTime = getReadingTime(textOnPage);

--- a/src/utils/articleI18n.ts
+++ b/src/utils/articleI18n.ts
@@ -1,0 +1,59 @@
+import { getCollection } from "astro:content";
+
+type SiteLang = "zh" | "en";
+
+type ArticleRoute = {
+	lang: SiteLang;
+	slug: string;
+};
+
+const ARTICLE_PATH_RE = /^\/(?:(en)\/)?article\/([^/]+)\/?$/;
+
+let cachedArticleLangSlugSet: Set<string> | null = null;
+
+const normalizeLang = (value: unknown): SiteLang => (value === "en" ? "en" : "zh");
+
+const buildKey = (lang: SiteLang, slug: string) => `${lang}:${slug}`;
+
+export const parseArticleRoute = (pathname: string): ArticleRoute | null => {
+	const match = pathname.match(ARTICLE_PATH_RE);
+	if (!match) {
+		return null;
+	}
+	const [, enPrefix, slug] = match;
+	return {
+		lang: enPrefix ? "en" : "zh",
+		slug,
+	};
+};
+
+const getArticleLangSlugSet = async (): Promise<Set<string>> => {
+	if (cachedArticleLangSlugSet) {
+		return cachedArticleLangSlugSet;
+	}
+	const posts = await getCollection("blog");
+	const set = new Set<string>();
+	for (const post of posts) {
+		const lang = normalizeLang(post.data.lang);
+		const slug = post.data.slug;
+		if (!slug) {
+			continue;
+		}
+		set.add(buildKey(lang, slug));
+	}
+	cachedArticleLangSlugSet = set;
+	return set;
+};
+
+export const getAlternateArticlePath = async (url: URL): Promise<string | null> => {
+	const parsed = parseArticleRoute(url.pathname);
+	if (!parsed) {
+		return null;
+	}
+	const targetLang: SiteLang = parsed.lang === "zh" ? "en" : "zh";
+	const set = await getArticleLangSlugSet();
+	if (!set.has(buildKey(targetLang, parsed.slug))) {
+		return null;
+	}
+	return targetLang === "en" ? `/en/article/${parsed.slug}` : `/article/${parsed.slug}`;
+};

--- a/src/utils/contentIntegrity.ts
+++ b/src/utils/contentIntegrity.ts
@@ -1,0 +1,33 @@
+const PRIMARY_FRONTMATTER_RE = /^---\s*\n[\s\S]*?\n---\s*\n?/;
+const LEADING_FRONTMATTER_RE = /^---\s*\n[\s\S]{0,2000}\n---\s*(?:\n|$)/;
+const LEADING_KEY_CLUSTER_RE = /^title:\s.+\n[\s\S]{0,400}?date:\s.+\n[\s\S]{0,400}?categories:\s.+/i;
+
+const HEAD_SLICE_LIMIT = 2200;
+
+export const assertNoEmbeddedFrontmatterAtBodyStart = (raw: string, fileRef: string): void => {
+	const source = String(raw || "");
+	if (!source.trim()) {
+		return;
+	}
+	const withoutPrimaryFrontmatter = source.replace(PRIMARY_FRONTMATTER_RE, "");
+	const bodyHead = withoutPrimaryFrontmatter.trimStart().slice(0, HEAD_SLICE_LIMIT);
+	if (!bodyHead) {
+		return;
+	}
+	if (LEADING_FRONTMATTER_RE.test(bodyHead) || LEADING_KEY_CLUSTER_RE.test(bodyHead)) {
+		throw new Error(`[content-integrity] duplicated frontmatter detected near body start: ${fileRef}`);
+	}
+};
+
+export const hasDuplicateFrontmatterAtBodyStart = (raw: string): boolean => {
+	const source = String(raw || "");
+	if (!source.trim()) {
+		return false;
+	}
+	const withoutPrimaryFrontmatter = source.replace(PRIMARY_FRONTMATTER_RE, "");
+	const bodyHead = withoutPrimaryFrontmatter.trimStart().slice(0, HEAD_SLICE_LIMIT);
+	if (!bodyHead) {
+		return false;
+	}
+	return LEADING_FRONTMATTER_RE.test(bodyHead) || LEADING_KEY_CLUSTER_RE.test(bodyHead);
+};

--- a/src/utils/contentIntegrityFs.ts
+++ b/src/utils/contentIntegrityFs.ts
@@ -1,0 +1,37 @@
+import { readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { hasDuplicateFrontmatterAtBodyStart } from "./contentIntegrity";
+
+const isMarkdownFile = (file: string): boolean => file.endsWith(".md") || file.endsWith(".mdx");
+
+const walkMarkdownFiles = (baseDir: string): string[] => {
+	const result: string[] = [];
+	const walk = (dir: string): void => {
+		for (const entry of readdirSync(dir, { withFileTypes: true })) {
+			const fullPath = path.join(dir, entry.name);
+			if (entry.isDirectory()) {
+				walk(fullPath);
+			} else if (entry.isFile() && isMarkdownFile(entry.name)) {
+				result.push(fullPath);
+			}
+		}
+	};
+	walk(baseDir);
+	return result;
+};
+
+export const validateMarkdownIntegrityInDir = (baseDir: string): void => {
+	const files = walkMarkdownFiles(baseDir);
+	const violations: string[] = [];
+	for (const filePath of files) {
+		const raw = readFileSync(filePath, "utf-8");
+		if (hasDuplicateFrontmatterAtBodyStart(raw)) {
+			violations.push(filePath);
+		}
+	}
+	if (violations.length > 0) {
+		throw new Error(
+			`[content-integrity] duplicated frontmatter detected in ${violations.length} file(s):\n${violations.join("\n")}`
+		);
+	}
+};

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,13 +1,27 @@
 import dayjs from "dayjs";
 import utc from "dayjs/plugin/utc.js";
 import timezone from "dayjs/plugin/timezone.js";
+import { assertNoEmbeddedFrontmatterAtBodyStart } from "./contentIntegrity";
 dayjs.extend(utc);
 dayjs.extend(timezone);
 // 设置中文语言环境
 import 'dayjs/locale/zh-cn'
 dayjs.locale('zh-cn');
 // 获取文章的描述
-const getDescription = (post: any, num: number = 150) => (post.rendered ? post.rendered.html.replace(/<[^>]+>/g, "").replace(/\s+/g, "") : post.body.replace(/\n/g, "").replace(/#/g, "")).slice(0, num) || '暂无简介'
+const getDescription = (post: any, num: number = 150) => {
+  const explicitDescription = typeof post?.data?.description === "string" ? post.data.description.trim() : "";
+  if (explicitDescription) {
+    return explicitDescription.slice(0, num);
+  }
+  const body = String(post?.body || "");
+  if (body) {
+    assertNoEmbeddedFrontmatterAtBodyStart(body, post?.id || post?.data?.slug || "unknown-post");
+  }
+  const source = post.rendered
+    ? post.rendered.html.replace(/<[^>]+>/g, "").replace(/\s+/g, "")
+    : body.replace(/\n/g, "").replace(/#/g, "");
+  return source.slice(0, num) || '暂无简介';
+}
 //处理时间
 const fmtTime = (time: any, fmt: string = 'MMMM D, YYYY') => dayjs(time).utc().format(fmt)
 // 处理日期 - 只显示总天数


### PR DESCRIPTION
Fixes #17

## 变更摘要
- 文章页 `hreflang` 与语言切换改为“仅在对侧稿件存在时才指向详情页”
- 增加正文重复 frontmatter 构建守卫，命中即 fail build
- `getDescription` 优先读取 frontmatter `description`，避免脏正文污染 SEO 摘要
- 清理 `obs-1e2bf5c7` 正文中的重复 frontmatter 块
- 补齐 OpenSpec `v2.1.1` proposal/design/tasks/spec delta

## Verification
- `pnpm build` ✅
- 负向验证：临时注入重复 frontmatter，构建失败并报 `[content-integrity]` ✅
