### PR TITLE
fix: <v2.1.2> core structure seo hotfix

### DIFF
--- a/openspec/changes/archive/2026-03-25-v2-1-2-core-structure-seo-hotfix/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-25-v2-1-2-core-structure-seo-hotfix/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-25

--- a/openspec/changes/archive/2026-03-25-v2-1-2-core-structure-seo-hotfix/design.md
+++ b/openspec/changes/archive/2026-03-25-v2-1-2-core-structure-seo-hotfix/design.md
@@ -1,0 +1,62 @@
+## Context
+
+`v2.1.2` 定位为 P0-A 止血版本，仅处理结构与 SEO 的硬失败点。当前问题集中在文章详情页模板与 Head 元数据链路：
+1) zh/en 文章模板存在闭合标签不匹配，导致结构不合法；
+2) 文章封面与页面类型在 `Layout -> Head` 传参链路上不一致，造成 OG 与 JSON-LD 类型可能偏离文章页语义；
+3) 英文分类静态路径只按现有英文文章生成，导航中的规范分类入口可能直接 404。
+
+约束：不改组件架构、不做样式重排、不引入新依赖，确保变更可在一次 `pnpm build` 和关键页面回归内完成。
+
+## Goals / Non-Goals
+
+**Goals:**
+- 修复 zh/en 文章详情模板的语义结构和闭合合法性。
+- 建立稳定的文章页 SEO 元数据传参（封面、页面类型）。
+- 消除英文核心分类入口的确定性 404。
+
+**Non-Goals:**
+- 不重构 Header/MobileSidebar 的交互一致性逻辑（归入 v2.1.3）。
+- 不调整视觉样式、字体、版式。
+- 不触发 schema/内容模型升级。
+
+## Decisions
+
+### 决策 1：直接修复文章页模板结构而非抽象新组件
+- 方案：在 `src/pages/article/[...article].astro` 与 `src/pages/en/article/[...article].astro` 修正错误闭合标签与语义容器，保持现有布局结构。
+- 原因：问题是模板级硬错误，局部修正成本最低且风险最可控。
+- 备选：抽取共享 ArticleDetail 组件统一渲染。
+- 不选原因：跨文件重构超出 `v2.1.2` 止血范围，回归面扩大。
+
+### 决策 2：在 Layout/Head 引入显式页面类型字段
+- 方案：`Layout.astro` 支持 `pageType` 与统一 `pageCover` 入口，`Head.astro` 以 `pageType` 决定 `og:type` 与 JSON-LD 类型；文章页显式传 `pageType="article"`。
+- 原因：以“封面是否存在”推断页面类型不稳定，且会把类型逻辑与内容素材耦合。
+- 备选：继续通过 `PageCover` 推断类型。
+- 不选原因：封面缺失或命名偏差会导致文章页被识别为 website，问题会重复出现。
+
+### 决策 3：英文分类路由对齐 canonical 分类全集
+- 方案：`src/pages/en/categories/[...categories].astro` 的 `getStaticPaths` 合并“英文文章实际分类”与“配置 canonical 分类键”。
+- 原因：导航入口基于 canonical 分类配置，路由生成必须覆盖该集合才能避免入口 404。
+- 备选：仅修 Header 导航，隐藏无文章分类。
+- 不选原因：隐藏入口属于交互策略变更，且无法保证其他入口（深链、外链）可达。
+
+## Risks / Trade-offs
+
+- [路由数量增加] 英文分类页会生成无文章的空列表页 → 通过复用现有 `Archive` 空态表现控制体验。
+- [元数据行为变化] 页面类型判定逻辑从隐式改为显式 → 默认值保持 `website`，仅文章页设置 `article`。
+- [模板修复回归] 结构标签调整可能影响样式挂载点 → 仅修改标签匹配，不调整 class 与层级语义。
+
+## Migration Plan
+
+1. 先修改 OpenSpec tasks，并按任务顺序改动 5 个目标文件。
+2. 执行 `pnpm build` 进行全量静态构建验证。
+3. 使用 `pnpm preview` 抽查关键页面：
+   - `/article/{slug}` 与 `/en/article/{slug}`：结构与 meta。
+   - `/en/categories/investment`（无英文内容场景）确认非 404。
+4. 若任一关键页面回归失败：
+   - 回滚对应文件到改动前版本（单文件粒度）；
+   - 保留已通过的独立修复项，重新验证。
+
+## Open Questions
+
+- 英文空分类页是否需要专门文案（当前沿用通用空列表表现）？本版本先不新增文案。
+- 是否在 v2.1.3 统一 `Layout` 历史 props 命名（`cover/pagecover`）？本版本先做向后兼容。

--- a/openspec/changes/archive/2026-03-25-v2-1-2-core-structure-seo-hotfix/proposal.md
+++ b/openspec/changes/archive/2026-03-25-v2-1-2-core-structure-seo-hotfix/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+`v2.1.1` 后，文章详情页仍存在三类会直接影响可用性与收录质量的硬问题：HTML 结构闭合错误、文章页 SEO 元数据传参不一致（封面与页面类型）、英文核心分类入口存在可复现 404。该问题集属于 `v2.x` 路线中的 P0 止血范围，需在 `v2.1.2` 单版本内最小修复并发布。
+
+## What Changes
+
+- 修复 `src/pages/article/[...article].astro` 与 `src/pages/en/article/[...article].astro` 的结构闭合与语义容器问题，确保文章详情页 HTML 结构稳定。
+- 修复 `Layout -> Head` 的文章 SEO 关键传参：统一封面字段传递，补充显式页面类型，保证 `og:type` 与 JSON-LD 输出与文章页一致。
+- 修复英文分类核心入口 404：英文分类路由静态路径从“仅已有英文文章分类”扩展为“全量规范分类键”，缺数据时输出空列表页而非 404。
+
+## Non-goals
+
+- 不做组件重构或目录迁移。
+- 不做样式风格调整与视觉升级。
+- 不引入新依赖，不处理 v2.1.3（交互一致性）范围事项。
+
+## Capabilities
+
+### New Capabilities
+- `astro-article-structure-seo-consistency`: 定义文章详情页结构合法性与 SEO 页面类型/封面元数据一致性约束。
+
+### Modified Capabilities
+- `astro-taxonomy-and-meta-normalization`: 增补英文分类路由生成约束，要求核心分类入口不因内容稀疏产生 404。
+
+## Impact
+
+- 受影响代码：`src/pages/article/[...article].astro`、`src/pages/en/article/[...article].astro`、`src/layouts/Layout/Layout.astro`、`src/components/Head/Head.astro`、`src/pages/en/categories/[...categories].astro`。
+- 受影响行为：文章详情页 DOM 结构、OpenGraph/JSON-LD 输出、英文分类入口可达性。
+- 外部依赖：无新增依赖。
+- Engine 依赖：无（本变更仅涉及 Astro 渲染与路由生成逻辑）。

--- a/openspec/changes/archive/2026-03-25-v2-1-2-core-structure-seo-hotfix/specs/astro-article-structure-seo-consistency/spec.md
+++ b/openspec/changes/archive/2026-03-25-v2-1-2-core-structure-seo-hotfix/specs/astro-article-structure-seo-consistency/spec.md
@@ -1,0 +1,34 @@
+## ADDED Requirements
+
+### Requirement: Article detail templates SHALL render valid semantic structure
+Article detail templates for both zh/en routes MUST keep semantic containers valid and tag closures balanced. Templates MUST NOT close with mismatched tags (for example, closing `</main>` for an opened `<article>`).
+
+#### Scenario: zh article template has balanced structural tags
+- **WHEN** building `/article/{slug}` pages
+- **THEN** page template renders with matched open/close tags for article metadata block and content block
+
+#### Scenario: en article template has balanced structural tags
+- **WHEN** building `/en/article/{slug}` pages
+- **THEN** page template renders with matched open/close tags for article metadata block and content block
+
+### Requirement: Article page SEO cover SHALL be passed through layout contract
+Article detail pages MUST provide resolved article cover through the shared Layout-to-Head contract so that metadata image output is article-scoped instead of site default.
+
+#### Scenario: article with custom cover uses article cover in metadata
+- **WHEN** an article has frontmatter `cover`
+- **THEN** Head metadata output uses the resolved article cover URL for OG/Twitter/JSON-LD image fields
+
+#### Scenario: article without cover falls back to site cover
+- **WHEN** an article has no frontmatter `cover`
+- **THEN** Head metadata output falls back to site-level cover URL without breaking build
+
+### Requirement: Head metadata type SHALL be explicit for article pages
+Head metadata generation MUST support explicit page type input and article pages MUST set this type to `article`. `og:type` and JSON-LD type selection MUST follow explicit page type instead of inferring from cover availability.
+
+#### Scenario: article page outputs article metadata type
+- **WHEN** rendering an article detail page
+- **THEN** `og:type` is `article` and JSON-LD uses BlogPosting schema
+
+#### Scenario: non-article page keeps website metadata type
+- **WHEN** rendering non-article routes (homepage, category, tag, archive)
+- **THEN** `og:type` is `website` and JSON-LD uses WebSite schema

--- a/openspec/changes/archive/2026-03-25-v2-1-2-core-structure-seo-hotfix/specs/astro-taxonomy-and-meta-normalization/spec.md
+++ b/openspec/changes/archive/2026-03-25-v2-1-2-core-structure-seo-hotfix/specs/astro-taxonomy-and-meta-normalization/spec.md
@@ -1,0 +1,12 @@
+## ADDED Requirements
+
+### Requirement: English category core routes SHALL be generated for all canonical category keys
+English category page static path generation MUST include the full canonical category key set defined by site taxonomy configuration, even when no English article currently belongs to a specific category.
+
+#### Scenario: canonical category without en posts still resolves
+- **WHEN** a canonical category has zero English articles
+- **THEN** `/en/categories/{category}` is still generated and renders a valid empty archive page instead of 404
+
+#### Scenario: canonical category with en posts remains accessible
+- **WHEN** a canonical category has English articles
+- **THEN** `/en/categories/{category}` renders article list normally with localized display text

--- a/openspec/changes/archive/2026-03-25-v2-1-2-core-structure-seo-hotfix/tasks.md
+++ b/openspec/changes/archive/2026-03-25-v2-1-2-core-structure-seo-hotfix/tasks.md
@@ -1,0 +1,24 @@
+## 1. OpenSpec 与基线对齐 [H]
+
+- [x] 1.1 [H] 校验 `v2-1-2-core-structure-seo-hotfix` artifacts 完整；AC: `openspec status --change v2-1-2-core-structure-seo-hotfix --json` 中 `tasks` 为 `ready` 或 `done`
+
+## 2. 文章页结构止血 [H]
+
+- [x] 2.1 [H] 修复 `src/pages/article/[...article].astro` 的语义容器闭合（`section/article` 标签成对）；AC: 页面模板无错配闭合标签
+- [x] 2.2 [H] 修复 `src/pages/en/article/[...article].astro` 的语义容器闭合（`div/article` 标签成对）；AC: 页面模板无错配闭合标签
+
+## 3. SEO 元数据传参修复 [H]
+
+- [x] 3.1 [H] 在 `src/layouts/Layout/Layout.astro` 统一 `pageCover/pageType` 入参并向后兼容旧 `cover/pagecover`；AC: Layout 可稳定向 Head 传递封面与页面类型
+- [x] 3.2 [H] 在 `src/components/Head/Head.astro` 改为基于显式 `PageType` 输出 `og:type` 与 JSON-LD 类型；AC: `article` 页面输出 BlogPosting，其他页面输出 WebSite
+- [x] 3.3 [H] 在 zh/en 文章页调用 Layout 时显式传递 `pageCover` 与 `pageType="article"`；AC: 文章页 OG 图片与类型符合预期
+
+## 4. 英文核心分类入口 404 修复 [H]
+
+- [x] 4.1 [H] 调整 `src/pages/en/categories/[...categories].astro` 路由生成逻辑：合并 canonical 分类键与英文已用分类；AC: `/en/categories/{canonical}` 全部可生成
+- [x] 4.2 [M] 回归英文分类空数据场景；AC: 无英文文章的分类路径返回有效页面（非 404）
+
+## 5. 构建与关键页面回归 [H]
+
+- [x] 5.1 [H] 执行 `pnpm build`；AC: 构建通过且无新增错误
+- [x] 5.2 [H] 执行关键页面回归（文章页 zh/en、英文无文章分类页）；AC: 结构闭合正确、SEO 元数据类型正确、核心入口不再 404

--- a/openspec/specs/astro-article-structure-seo-consistency/spec.md
+++ b/openspec/specs/astro-article-structure-seo-consistency/spec.md
@@ -1,0 +1,38 @@
+# astro-article-structure-seo-consistency Specification
+
+## Purpose
+TBD - created by archiving change v2-1-2-core-structure-seo-hotfix. Update Purpose after archive.
+## Requirements
+### Requirement: Article detail templates SHALL render valid semantic structure
+Article detail templates for both zh/en routes MUST keep semantic containers valid and tag closures balanced. Templates MUST NOT close with mismatched tags (for example, closing `</main>` for an opened `<article>`).
+
+#### Scenario: zh article template has balanced structural tags
+- **WHEN** building `/article/{slug}` pages
+- **THEN** page template renders with matched open/close tags for article metadata block and content block
+
+#### Scenario: en article template has balanced structural tags
+- **WHEN** building `/en/article/{slug}` pages
+- **THEN** page template renders with matched open/close tags for article metadata block and content block
+
+### Requirement: Article page SEO cover SHALL be passed through layout contract
+Article detail pages MUST provide resolved article cover through the shared Layout-to-Head contract so that metadata image output is article-scoped instead of site default.
+
+#### Scenario: article with custom cover uses article cover in metadata
+- **WHEN** an article has frontmatter `cover`
+- **THEN** Head metadata output uses the resolved article cover URL for OG/Twitter/JSON-LD image fields
+
+#### Scenario: article without cover falls back to site cover
+- **WHEN** an article has no frontmatter `cover`
+- **THEN** Head metadata output falls back to site-level cover URL without breaking build
+
+### Requirement: Head metadata type SHALL be explicit for article pages
+Head metadata generation MUST support explicit page type input and article pages MUST set this type to `article`. `og:type` and JSON-LD type selection MUST follow explicit page type instead of inferring from cover availability.
+
+#### Scenario: article page outputs article metadata type
+- **WHEN** rendering an article detail page
+- **THEN** `og:type` is `article` and JSON-LD uses BlogPosting schema
+
+#### Scenario: non-article page keeps website metadata type
+- **WHEN** rendering non-article routes (homepage, category, tag, archive)
+- **THEN** `og:type` is `website` and JSON-LD uses WebSite schema
+

--- a/openspec/specs/astro-taxonomy-and-meta-normalization/spec.md
+++ b/openspec/specs/astro-taxonomy-and-meta-normalization/spec.md
@@ -1,8 +1,6 @@
 ## Purpose
 定义 Astro 分类与元数据渲染的规范化约束，确保分类键稳定、展示可本地化、元数据字段按类型消费。
-
 ## Requirements
-
 ### Requirement: categories SHALL be canonical-only across all aggregations
 
 Category counting, grouping, filtering, and page generation MUST use canonical category keys only. Alias-based normalization MUST NOT be used in v2.1.
@@ -50,3 +48,15 @@ Article description resolution MUST prefer frontmatter `description` when presen
 #### Scenario: frontmatter description missing
 - **WHEN** `description` is absent in frontmatter
 - **THEN** system falls back to generated excerpt from sanitized body content
+
+### Requirement: English category core routes SHALL be generated for all canonical category keys
+English category page static path generation MUST include the full canonical category key set defined by site taxonomy configuration, even when no English article currently belongs to a specific category.
+
+#### Scenario: canonical category without en posts still resolves
+- **WHEN** a canonical category has zero English articles
+- **THEN** `/en/categories/{category}` is still generated and renders a valid empty archive page instead of 404
+
+#### Scenario: canonical category with en posts remains accessible
+- **WHEN** a canonical category has English articles
+- **THEN** `/en/categories/{category}` renders article list normally with localized display text
+

--- a/src/components/Head/Head.astro
+++ b/src/components/Head/Head.astro
@@ -26,7 +26,7 @@ const renderEnAlt = !articleRoute || lang === 'en' || hasArticleAltLanguage;
 const xDefaultHref = lang === 'zh' ? canonicalURL : (renderZhAlt ? altLangURL : canonicalURL);
 
 // 页面内容的元数据
-const { Title, Keywords, Description, PageCover } = Astro.props;
+const { Title, Keywords, Description, PageCover, PageType } = Astro.props;
 // 使用 i18n 替换 Config 中的硬编码文本
 const SiteName = t('site.title');
 const Subtitle = t('site.subtitle');
@@ -39,6 +39,8 @@ const WebTitle = Title || SiteName;
 const SiteCover = Site + Cover;
 const WebCover = PageCover || SiteCover;
 const MetaDescription = Description || SiteDescription;
+const resolvedPageType = PageType === "article" ? "article" : "website";
+const isArticlePage = resolvedPageType === "article";
 
 // Schema.org 结构化数据（JSON-LD）
 const WebSiteData = { "@context": "https://schema.org", "@type": "WebSite", name: WebTitle, url: canonicalURL, description: MetaDescription, image: { "@type": "ImageObject", url: SiteCover } };
@@ -80,8 +82,8 @@ const ArticleData = { "@context": "https://schema.org", "@type": "BlogPosting", 
 	<meta name="robots" content="index, follow, max-image-preview:large" />
 	<meta itemprop="image" content={WebCover} />
 	<!-- Open Graph -->
-	<meta property="article:author" content={Author} />
-	<meta property="og:type" content={PageCover ? "article" : "website"} />
+	{isArticlePage && <meta property="article:author" content={Author} />}
+	<meta property="og:type" content={resolvedPageType} />
 	<meta property="og:site_name" content={SiteName} />
 	<meta property="og:title" content={WebTitle} />
 	<meta property="og:description" content={MetaDescription} />
@@ -97,7 +99,7 @@ const ArticleData = { "@context": "https://schema.org", "@type": "BlogPosting", 
 	<meta name="twitter:url" content={canonicalURL} />
 	<meta name="twitter:image" content={WebCover} />
 	<!-- 输出结构化数据 -->
-	<script type="application/ld+json" set:html={JSON.stringify(PageCover ? ArticleData : WebSiteData)} is:inline />
+	<script type="application/ld+json" set:html={JSON.stringify(isArticlePage ? ArticleData : WebSiteData)} is:inline />
 	<!-- Sitemap -->
 	<link rel="sitemap" href="/sitemap-index.xml" />
 	<!-- DNS预解析 -->

--- a/src/layouts/Layout/Layout.astro
+++ b/src/layouts/Layout/Layout.astro
@@ -1,5 +1,17 @@
 ---
-const { title, keywords, description, pagecover, activeNav, Home, headings } = Astro.props;
+const {
+	title,
+	keywords,
+	description,
+	pagecover,
+	pageCover,
+	cover,
+	pageType,
+	activeNav,
+	Home,
+	headings
+} = Astro.props;
+const resolvedPageCover = pageCover || pagecover || cover;
 // 网站配置
 import SITE_INFO from "@/config";
 const { GoogleAds, Theme } = SITE_INFO;
@@ -28,7 +40,7 @@ const lang = getLangFromUrl(Astro.url);
 ---
 
 <html lang={lang}>
-	<Head Title={title} Keywords={keywords} Description={description} PageCover={pagecover}>
+	<Head Title={title} Keywords={keywords} Description={description} PageCover={resolvedPageCover} PageType={pageType}>
 		<!-- 谷歌广告JS加载项 -->
 		{ad_Client && (asideAD_Slot || articleAD_Slot) && <script is:inline async src={`https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=${ad_Client}`} crossorigin="anonymous" />}
 		<!-- 彩旗🎈 - 已禁用 -->

--- a/src/pages/article/[...article].astro
+++ b/src/pages/article/[...article].astro
@@ -44,7 +44,14 @@ import GoogleAd from "@/components/GoogleAd/GoogleAd.astro";
 
 ---
 
-<Layout title={post.data.title || Title} description={description} cover={ARTICLE_COVER} activeNav={post.data.categories} headings={headings}>
+<Layout
+	title={post.data.title || Title}
+	description={description}
+	pageCover={ARTICLE_COVER}
+	pageType="article"
+	activeNav={post.data.categories}
+	headings={headings}
+>
 	<article class="
 		w-full
 		bg-white dark:bg-[#252525]
@@ -77,7 +84,7 @@ import GoogleAd from "@/components/GoogleAd/GoogleAd.astro";
 					</span>
 				</section>
 		</header>
-		<article
+		<main
 			class="
 			prose lg:prose-xl
 			prose-zinc

--- a/src/pages/en/article/[...article].astro
+++ b/src/pages/en/article/[...article].astro
@@ -45,7 +45,13 @@ import GoogleAd from "@/components/GoogleAd/GoogleAd.astro";
 
 ---
 
-<Layout title={post.data.title} description={post.data.description} headings={headings}>
+<Layout
+	title={post.data.title}
+	description={description}
+	pageCover={ARTICLE_COVER}
+	pageType="article"
+	headings={headings}
+>
   <article class="flex flex-col gap-10">
     <header class="flex flex-col gap-6">
       <h1 class="text-4xl max-md:text-2xl font-bold text-primary dark:text-[#e8e8e8] leading-tight">
@@ -71,9 +77,9 @@ import GoogleAd from "@/components/GoogleAd/GoogleAd.astro";
 						<Icon name="clock" class="w-4 h-4 text-primary/80" />
 						{t('post.readTime')} ≈ {Math.ceil(readingMinutes)} {t('post.readTime')}
 					</span>
-				</section>
+				</div>
 		</header>
-		<article
+		<main
 			class="
 			prose lg:prose-xl
 			prose-zinc

--- a/src/pages/en/categories/[...categories].astro
+++ b/src/pages/en/categories/[...categories].astro
@@ -1,7 +1,6 @@
 ---
 import { getCollection } from "astro:content";
-import { getLangFromUrl, useTranslations } from '@/i18n/utils';
-import { getCategoryDisplayName } from "@/utils/categoryMapping";
+import { getAllCategoryPaths, getCategoryDisplayName } from "@/utils/categoryMapping";
 // 公共 Layout
 import Layout from "@/layouts/Layout/Layout.astro";
 // 文章列表组件
@@ -12,11 +11,12 @@ import { getCategoriesList } from "@/utils/getArchive";
 export async function getStaticPaths() {
   const posts = await getCollection("blog");
   const enPosts = posts.filter((post: any) => post.data.lang === 'en');
-  
-  // Get unique categories from English posts
-  const categories = [...new Set(enPosts.map((post: any) => post.data.categories))];
-  
-  return categories.map((category) => ({
+
+  const usedCategories = new Set(enPosts.map((post: any) => post.data.categories));
+  const canonicalCategories = getAllCategoryPaths();
+  const allCategories = new Set([...usedCategories, ...canonicalCategories]);
+
+  return Array.from(allCategories).map((category: string) => ({
     params: { categories: category },
   }));
 }


### PR DESCRIPTION
## Summary
- 修复中英文文章详情页结构闭合问题，消除语义容器错配
- 修复 `Layout -> Head` SEO 传参契约：统一 `pageCover` 并引入显式 `pageType`
- 修复英文 canonical 分类核心入口 404：生成全量 canonical `/en/categories/*` 路由
- 归档 OpenSpec change `v2-1-2-core-structure-seo-hotfix`，并同步主 specs

## Issue
Fixes #20

## Verification
- `openspec archive v2-1-2-core-structure-seo-hotfix -y`
  - 输出包含：`Specs updated successfully`，`archived as '2026-03-25-v2-1-2-core-structure-seo-hotfix'`
- `pnpm build`
  - 结果：`[build] Complete!`
  - 关键路由生成：`/en/categories/investment|zhejiang-business|philosophy|life`
- 关键产物检查（dist）
  - 文章页：`og:type=article`，JSON-LD `@type=BlogPosting`
  - 非文章页：`og:type=website`，JSON-LD `@type=WebSite`

## Notes
- 无法自动补齐 Project 字段：当前 `gh` token 缺少 `read:project` scope（已在 Issue 记录）。
